### PR TITLE
Add custom file filter

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,0 +1,4 @@
+src:
+  - go.mod
+  - 'cmd/**'
+  - 'internal/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
-        filters: .github/filters.yml
+        filters: .github/file-filters.yml
 
   lint:
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       src: ${{ steps.filter.outputs.src }}
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - uses: dorny/paths-filter@v2
       id: filter
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,32 @@
+
 name: ci
 
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'internal/**'
-      - 'cmd/**'
 
 jobs:
+  detect-changes:
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: .github/filters.yml
 
   lint:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.src == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: golangci/golangci-lint-action@v2
 
   unit-test:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.src == 'true' }}
     runs-on: ubuntu-latest
     container: golang:latest
     steps:


### PR DESCRIPTION
If we make GitHub Action jobs required in order to merge, then on every PR GH automatically creates a status check in the pending state. This means that this workflow needs to run in order to update the status checks. I cannot use the GH workflow path filter because the job would be skipped.